### PR TITLE
Create UI for q&a part

### DIFF
--- a/src/components/QuestionHistoryManagement.tsx
+++ b/src/components/QuestionHistoryManagement.tsx
@@ -1,0 +1,240 @@
+import React, { useState } from 'react';
+import { Search } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import CustomPagination from "@/components/ui/custom-pagination";
+import { Badge } from "@/components/ui/badge";
+
+interface QuestionHistoryManagementProps {
+  language: 'en' | 'vi';
+}
+
+interface TestHistory {
+  id: number;
+  dateTest: string;
+  email: string;
+  fullName: string;
+  result: 'passed' | 'failed';
+  correctAnswers: number;
+  totalQuestions: number;
+  assessmentType: string;
+}
+
+// Mock data for demonstration
+const mockHistory: TestHistory[] = [
+  {
+    id: 1,
+    dateTest: '03/09/2024',
+    email: 'dianaduongle@gmail.com',
+    fullName: 'Diana Duong Le',
+    result: 'failed',
+    correctAnswers: 3,
+    totalQuestions: 5,
+    assessmentType: 'rule'
+  },
+  {
+    id: 2,
+    dateTest: '03/09/2024',
+    email: 'nguyenthanhnam@gmail.com',
+    fullName: 'Nguyen Thanh Nam',
+    result: 'passed',
+    correctAnswers: 4,
+    totalQuestions: 5,
+    assessmentType: 'rule'
+  }
+];
+
+const QuestionHistoryManagement = ({ language }: QuestionHistoryManagementProps) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedType, setSelectedType] = useState('rule');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  // Handle search and filter
+  const filteredHistory = mockHistory.filter(history => 
+    (history.assessmentType === selectedType) &&
+    (history.email.toLowerCase().includes(searchQuery.toLowerCase()) ||
+     history.fullName.toLowerCase().includes(searchQuery.toLowerCase()))
+  );
+
+  // Pagination
+  const indexOfLastItem = currentPage * rowsPerPage;
+  const indexOfFirstItem = indexOfLastItem - rowsPerPage;
+  const paginatedHistory = filteredHistory.slice(indexOfFirstItem, indexOfLastItem);
+  const totalPages = Math.ceil(filteredHistory.length / rowsPerPage);
+
+  // Translations
+  const t = {
+    en: {
+      pageTitle: "History of tests",
+      search: "Search by email",
+      dateTest: "Date Test",
+      email: "Email",
+      fullName: "Full Name",
+      result: "Result",
+      correctAnswers: "Number Of Correct Answers",
+      assessmentType: "Assessment Type",
+      passed: "Passed",
+      failed: "Failed",
+      import: "Import",
+      export: "Export",
+      selectType: "Select assessment type",
+      showing: "Showing",
+      of: "of",
+      perPage: "per page",
+      rowsPerPage: "Rows per page"
+    },
+    vi: {
+      pageTitle: "Lịch sử làm bài",
+      search: "Tìm kiếm theo email",
+      dateTest: "Ngày thi",
+      email: "Email",
+      fullName: "Họ và tên",
+      result: "Kết quả",
+      correctAnswers: "Số câu đúng",
+      assessmentType: "Loại bài thi",
+      passed: "Đạt",
+      failed: "Không đạt",
+      import: "Nhập",
+      export: "Xuất",
+      selectType: "Chọn loại bài thi",
+      showing: "Hiển thị",
+      of: "trong số",
+      perPage: "mỗi trang",
+      rowsPerPage: "Hàng mỗi trang"
+    }
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="flex flex-col space-y-6">
+        {/* Header */}
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold">{t[language].pageTitle}</h1>
+        </div>
+
+        {/* Search and Filter */}
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-4 flex-1">
+            <div className="relative flex-1">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder={t[language].search}
+                className="pl-8"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+            <Select value={selectedType} onValueChange={setSelectedType}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder={t[language].selectType} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="rule">Rule</SelectItem>
+                <SelectItem value="default">Default</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* History Table */}
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="whitespace-nowrap">{t[language].dateTest}</TableHead>
+                <TableHead className="whitespace-nowrap">{t[language].email}</TableHead>
+                <TableHead className="whitespace-nowrap">{t[language].fullName}</TableHead>
+                <TableHead className="whitespace-nowrap">{t[language].result}</TableHead>
+                <TableHead className="whitespace-nowrap">{t[language].correctAnswers}</TableHead>
+                <TableHead className="whitespace-nowrap">{t[language].assessmentType}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {paginatedHistory.map((history) => (
+                <TableRow key={history.id}>
+                  <TableCell className="whitespace-nowrap">{history.dateTest}</TableCell>
+                  <TableCell className="whitespace-nowrap max-w-[200px] truncate">
+                    {history.email}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap max-w-[200px] truncate">
+                    {history.fullName}
+                  </TableCell>
+                  <TableCell>
+                    <Badge 
+                      variant={history.result === 'passed' ? 'default' : 'destructive'}
+                    >
+                      {history.result === 'passed' ? t[language].passed : t[language].failed}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    {history.correctAnswers}/{history.totalQuestions}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap">{history.assessmentType}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Pagination */}
+        <div className="flex justify-between items-center">
+          <div className="flex items-center space-x-2">
+            <Select
+              value={rowsPerPage.toString()}
+              onValueChange={(value) => {
+                setRowsPerPage(parseInt(value));
+                setCurrentPage(1);
+              }}
+            >
+              <SelectTrigger className="w-[100px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[5, 10, 20, 30, 40, 50].map((pageSize) => (
+                  <SelectItem key={pageSize} value={pageSize.toString()}>
+                    {pageSize} {t[language].perPage}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <span className="text-sm text-muted-foreground">
+              {t[language].showing} {((currentPage - 1) * rowsPerPage) + 1}-
+              {Math.min(currentPage * rowsPerPage, filteredHistory.length)} {t[language].of}{" "}
+              {filteredHistory.length}
+            </span>
+          </div>
+          <CustomPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            rowsPerPage={rowsPerPage}
+            onPageChange={setCurrentPage}
+            onRowsPerPageChange={setRowsPerPage}
+            translations={{
+              showing: t[language].showing,
+              of: t[language].of,
+              perPage: t[language].perPage
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuestionHistoryManagement; 

--- a/src/components/QuestionManagement.tsx
+++ b/src/components/QuestionManagement.tsx
@@ -1,0 +1,515 @@
+import React, { useState, useRef } from 'react';
+import { Search, Edit2, Plus, Download, Upload, Trash2, X } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/use-toast";
+import CustomPagination from "@/components/ui/custom-pagination";
+import { Switch } from "@/components/ui/switch";
+
+interface QuestionManagementProps {
+  language: 'en' | 'vi';
+}
+
+interface Question {
+  id: number;
+  question: string;
+  level: number;
+  answers: Answer[];
+  type: string;
+}
+
+interface Answer {
+  id: number;
+  text: string;
+  isCorrect: boolean;
+}
+
+// Mock data for demonstration
+const mockQuestions: Question[] = [
+  {
+    id: 1,
+    question: 'Khi nào là lúc bạn đặt câu hỏi cho kênh Youtube NhiLe. CHỌN 1 CÂU ĐÚNG.',
+    level: 1,
+    type: 'rule',
+    answers: [
+      { id: 1, text: 'Xem hết tất cả các Livestream', isCorrect: true },
+      { id: 2, text: 'Xem đến Livestream số 100', isCorrect: false },
+      { id: 3, text: 'Khi có câu hỏi trong đầu và chưa xem hết livestream', isCorrect: false },
+      { id: 4, text: 'Khi nào cũng được', isCorrect: false }
+    ]
+  }
+];
+
+const QuestionManagement = ({ language }: QuestionManagementProps) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedType, setSelectedType] = useState('rule');
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editingQuestion, setEditingQuestion] = useState<Question | null>(null);
+  const [deletingQuestion, setDeletingQuestion] = useState<Question | null>(null);
+  const [questions, setQuestions] = useState<Question[]>(mockQuestions);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  // Handle file import
+  const handleImport = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        try {
+          const importedQuestions = JSON.parse(e.target?.result as string);
+          setQuestions([...questions, ...importedQuestions]);
+          toast({
+            title: language === 'en' ? 'Success' : 'Thành công',
+            description: language === 'en' ? 'Questions imported successfully' : 'Nhập câu hỏi thành công',
+          });
+        } catch (error) {
+          toast({
+            title: language === 'en' ? 'Error' : 'Lỗi',
+            description: language === 'en' ? 'Failed to import questions' : 'Nhập câu hỏi thất bại',
+            variant: 'destructive',
+          });
+        }
+      };
+      reader.readAsText(file);
+    }
+  };
+
+  // Handle export
+  const handleExport = () => {
+    const filteredQuestions = questions.filter(q => q.type === selectedType);
+    const dataStr = JSON.stringify(filteredQuestions, null, 2);
+    const dataBlob = new Blob([dataStr], { type: 'application/json' });
+    const url = URL.createObjectURL(dataBlob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `questions_${selectedType}_${new Date().toISOString().split('T')[0]}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  // Handle search
+  const filteredQuestions = questions.filter(question => 
+    question.type === selectedType &&
+    question.question.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  // Pagination
+  const indexOfLastQuestion = currentPage * rowsPerPage;
+  const indexOfFirstQuestion = indexOfLastQuestion - rowsPerPage;
+  const paginatedQuestions = filteredQuestions.slice(indexOfFirstQuestion, indexOfLastQuestion);
+  const totalPages = Math.ceil(filteredQuestions.length / rowsPerPage);
+
+  // Handle edit
+  const handleEdit = (question: Question) => {
+    setEditingQuestion(question);
+    setIsEditDialogOpen(true);
+  };
+
+  const handleSaveEdit = () => {
+    if (editingQuestion) {
+      setQuestions(questions.map(question => 
+        question.id === editingQuestion.id ? editingQuestion : question
+      ));
+      setIsEditDialogOpen(false);
+      setEditingQuestion(null);
+      toast({
+        title: language === 'en' ? 'Success' : 'Thành công',
+        description: language === 'en' ? 'Question updated successfully' : 'Cập nhật thành công',
+      });
+    }
+  };
+
+  // Handle delete
+  const handleDelete = (question: Question) => {
+    setDeletingQuestion(question);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleConfirmDelete = () => {
+    if (deletingQuestion) {
+      setQuestions(questions.filter(question => question.id !== deletingQuestion.id));
+      setIsDeleteDialogOpen(false);
+      setDeletingQuestion(null);
+      toast({
+        title: language === 'en' ? 'Success' : 'Thành công',
+        description: language === 'en' ? 'Question deleted successfully' : 'Xóa thành công',
+      });
+    }
+  };
+
+  // Handle add answer
+  const handleAddAnswer = () => {
+    if (editingQuestion) {
+      const newAnswer: Answer = {
+        id: Math.max(...editingQuestion.answers.map(a => a.id), 0) + 1,
+        text: '',
+        isCorrect: false
+      };
+      setEditingQuestion({
+        ...editingQuestion,
+        answers: [...editingQuestion.answers, newAnswer]
+      });
+    }
+  };
+
+  // Handle remove answer
+  const handleRemoveAnswer = (answerId: number) => {
+    if (editingQuestion) {
+      setEditingQuestion({
+        ...editingQuestion,
+        answers: editingQuestion.answers.filter(a => a.id !== answerId)
+      });
+    }
+  };
+
+  // Translations
+  const t = {
+    en: {
+      pageTitle: "Questions",
+      search: "Search questions",
+      create: "Create",
+      import: "Import",
+      export: "Export",
+      question: "Question",
+      level: "Level",
+      answers: "Answers",
+      actions: "Actions",
+      createQuestion: "Create Question",
+      editQuestion: "Edit Question",
+      deleteQuestion: "Delete Question",
+      deleteConfirmation: "Are you sure you want to delete this question?",
+      deleteWarning: "This action cannot be undone.",
+      cancel: "Cancel",
+      save: "Save",
+      delete: "Delete",
+      required: "Required",
+      showing: "Showing",
+      of: "of",
+      perPage: "per page",
+      rowsPerPage: "Rows per page",
+      addAnswer: "Add answer",
+      selectType: "Select question type",
+      correct: "Correct"
+    },
+    vi: {
+      pageTitle: "Câu hỏi",
+      search: "Tìm kiếm câu hỏi",
+      create: "Tạo mới",
+      import: "Nhập",
+      export: "Xuất",
+      question: "Câu hỏi",
+      level: "Cấp độ",
+      answers: "Câu trả lời",
+      actions: "Thao tác",
+      createQuestion: "Tạo câu hỏi",
+      editQuestion: "Chỉnh sửa câu hỏi",
+      deleteQuestion: "Xóa câu hỏi",
+      deleteConfirmation: "Bạn có chắc chắn muốn xóa câu hỏi này?",
+      deleteWarning: "Hành động này không thể hoàn tác.",
+      cancel: "Hủy",
+      save: "Lưu",
+      delete: "Xóa",
+      required: "Bắt buộc",
+      showing: "Hiển thị",
+      of: "trong số",
+      perPage: "mỗi trang",
+      rowsPerPage: "Hàng mỗi trang",
+      addAnswer: "Thêm câu trả lời",
+      selectType: "Chọn loại câu hỏi",
+      correct: "Đúng"
+    }
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="flex flex-col space-y-6">
+        {/* Header */}
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold">{t[language].pageTitle}</h1>
+        </div>
+
+        {/* Type Selection and Actions */}
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <Select value={selectedType} onValueChange={setSelectedType}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder={t[language].selectType} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="rule">Rule</SelectItem>
+                <SelectItem value="default">Default</SelectItem>
+              </SelectContent>
+            </Select>
+            <input
+              type="file"
+              ref={fileInputRef}
+              className="hidden"
+              accept=".json"
+              onChange={handleFileChange}
+            />
+            <Button variant="outline" onClick={handleImport}>
+              <Upload className="mr-2 h-4 w-4" />
+              {t[language].import}
+            </Button>
+            <Button variant="outline" onClick={handleExport}>
+              <Download className="mr-2 h-4 w-4" />
+              {t[language].export}
+            </Button>
+          </div>
+          <Button onClick={() => {
+            setEditingQuestion({
+              id: Math.max(...questions.map(q => q.id), 0) + 1,
+              question: '',
+              level: 1,
+              type: selectedType,
+              answers: []
+            });
+            setIsEditDialogOpen(true);
+          }}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t[language].create}
+          </Button>
+        </div>
+
+        {/* Search */}
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder={t[language].search}
+            className="pl-8"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </div>
+
+        {/* Questions List */}
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[60%]">{t[language].question}</TableHead>
+                <TableHead>{t[language].level}</TableHead>
+                <TableHead className="text-right">{t[language].actions}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {paginatedQuestions.map((question) => (
+                <TableRow key={question.id}>
+                  <TableCell className="font-medium">{question.question}</TableCell>
+                  <TableCell>{question.level}</TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button variant="ghost" size="icon" onClick={() => handleEdit(question)}>
+                        <Edit2 className="h-4 w-4" />
+                      </Button>
+                      <Button variant="ghost" size="icon" onClick={() => handleDelete(question)}>
+                        <Trash2 className="h-4 w-4 text-red-500" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Pagination */}
+        <div className="flex justify-between items-center">
+          <div className="flex items-center space-x-2">
+            <Select
+              value={rowsPerPage.toString()}
+              onValueChange={(value) => {
+                setRowsPerPage(parseInt(value));
+                setCurrentPage(1);
+              }}
+            >
+              <SelectTrigger className="w-[100px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[5, 10, 20, 30, 40, 50].map((pageSize) => (
+                  <SelectItem key={pageSize} value={pageSize.toString()}>
+                    {pageSize} {t[language].perPage}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <span className="text-sm text-muted-foreground">
+              {t[language].showing} {((currentPage - 1) * rowsPerPage) + 1}-
+              {Math.min(currentPage * rowsPerPage, filteredQuestions.length)} {t[language].of}{" "}
+              {filteredQuestions.length}
+            </span>
+          </div>
+          <CustomPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            rowsPerPage={rowsPerPage}
+            onPageChange={setCurrentPage}
+            onRowsPerPageChange={setRowsPerPage}
+            translations={{
+              showing: t[language].showing,
+              of: t[language].of,
+              perPage: t[language].perPage
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Edit Dialog */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className="sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>
+              {editingQuestion?.id ? t[language].editQuestion : t[language].createQuestion}
+            </DialogTitle>
+          </DialogHeader>
+          
+          <div className="space-y-4 py-4">
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="question">
+                  {t[language].question} <span className="text-red-500">*</span>
+                </Label>
+                <textarea
+                  id="question"
+                  className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  value={editingQuestion?.question || ''}
+                  onChange={(e) => setEditingQuestion(prev => ({ ...prev!, question: e.target.value }))}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="level">
+                  {t[language].level} <span className="text-red-500">*</span>
+                </Label>
+                <Select
+                  value={editingQuestion?.level.toString()}
+                  onValueChange={(value) => setEditingQuestion(prev => ({ ...prev!, level: parseInt(value) }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[1, 2, 3, 4, 5].map((level) => (
+                      <SelectItem key={level} value={level.toString()}>{level}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid gap-2">
+                <div className="flex justify-between items-center">
+                  <Label>{t[language].answers}</Label>
+                  <Button type="button" variant="outline" size="sm" onClick={handleAddAnswer}>
+                    <Plus className="h-4 w-4 mr-1" />
+                    {t[language].addAnswer}
+                  </Button>
+                </div>
+                <div className="space-y-2">
+                  {editingQuestion?.answers.map((answer, index) => (
+                    <div key={answer.id} className="flex items-center gap-2">
+                      <Input
+                        value={answer.text}
+                        onChange={(e) => {
+                          const newAnswers = [...editingQuestion.answers];
+                          newAnswers[index] = { ...answer, text: e.target.value };
+                          setEditingQuestion({ ...editingQuestion, answers: newAnswers });
+                        }}
+                        placeholder={`${t[language].answers} ${index + 1}`}
+                      />
+                      <div className="flex items-center gap-2">
+                        <Switch
+                          checked={answer.isCorrect}
+                          onCheckedChange={(checked) => {
+                            const newAnswers = [...editingQuestion.answers];
+                            newAnswers[index] = { ...answer, isCorrect: checked };
+                            setEditingQuestion({ ...editingQuestion, answers: newAnswers });
+                          }}
+                        />
+                        <span className="text-sm">{t[language].correct}</span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRemoveAnswer(answer.id)}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+              {t[language].cancel}
+            </Button>
+            <Button onClick={handleSaveEdit}>
+              {t[language].save}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t[language].deleteQuestion}</DialogTitle>
+            <DialogDescription>
+              {t[language].deleteConfirmation}
+              <br />
+              <span className="text-red-500">{t[language].deleteWarning}</span>
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
+              {t[language].cancel}
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmDelete}>
+              {t[language].delete}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default QuestionManagement; 

--- a/src/components/QuestionTypeManagement.tsx
+++ b/src/components/QuestionTypeManagement.tsx
@@ -1,0 +1,427 @@
+import React, { useState, useRef } from 'react';
+import { Search, Edit2, Plus, Download, Upload, Trash2 } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/use-toast";
+import CustomPagination from "@/components/ui/custom-pagination";
+
+interface QuestionTypeManagementProps {
+  language: 'en' | 'vi';
+}
+
+interface QuestionType {
+  id: number;
+  name: string;
+  template: string;
+  team: string;
+  title: string;
+  link: string;
+  description?: string;
+}
+
+// Mock data for demonstration
+const mockQuestionTypes: QuestionType[] = [
+  {
+    id: 1,
+    name: 'rule',
+    template: 'Rule',
+    team: '',
+    title: 'Bài kiểm tra nội quy và văn hóa',
+    link: 'https://tnv.nhi.sg/questions/rule-qs1',
+    description: ''
+  },
+  {
+    id: 2,
+    name: 'capcut',
+    template: 'Default',
+    team: 'Editor',
+    title: 'Bài kiểm tra Editor',
+    link: 'https://tnv.nhi.sg/questions/capcut-qs2'
+  },
+  {
+    id: 3,
+    name: 'marketing',
+    template: 'Default',
+    team: 'Editor',
+    title: 'Bài kiểm tra Training Editor',
+    link: 'https://tnv.nhi.sg/questions/marketing-qs3'
+  }
+];
+
+const QuestionTypeManagement = ({ language }: QuestionTypeManagementProps) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editingType, setEditingType] = useState<QuestionType | null>(null);
+  const [deletingType, setDeletingType] = useState<QuestionType | null>(null);
+  const [questionTypes, setQuestionTypes] = useState<QuestionType[]>(mockQuestionTypes);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  // Handle search
+  const filteredTypes = questionTypes.filter(type => 
+    type.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    type.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    type.team.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  // Pagination
+  const indexOfLastType = currentPage * rowsPerPage;
+  const indexOfFirstType = indexOfLastType - rowsPerPage;
+  const paginatedTypes = filteredTypes.slice(indexOfFirstType, indexOfLastType);
+  const totalPages = Math.ceil(filteredTypes.length / rowsPerPage);
+
+  // Handle edit
+  const handleEdit = (type: QuestionType) => {
+    setEditingType(type);
+    setIsEditDialogOpen(true);
+  };
+
+  const handleSaveEdit = () => {
+    if (editingType) {
+      setQuestionTypes(questionTypes.map(type => 
+        type.id === editingType.id ? editingType : type
+      ));
+      setIsEditDialogOpen(false);
+      setEditingType(null);
+      toast({
+        title: language === 'en' ? 'Success' : 'Thành công',
+        description: language === 'en' ? 'Question type updated successfully' : 'Cập nhật thành công',
+      });
+    }
+  };
+
+  // Handle delete
+  const handleDelete = (type: QuestionType) => {
+    setDeletingType(type);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleConfirmDelete = () => {
+    if (deletingType) {
+      setQuestionTypes(questionTypes.filter(type => type.id !== deletingType.id));
+      setIsDeleteDialogOpen(false);
+      setDeletingType(null);
+      toast({
+        title: language === 'en' ? 'Success' : 'Thành công',
+        description: language === 'en' ? 'Question type deleted successfully' : 'Xóa thành công',
+      });
+    }
+  };
+
+  // Translations
+  const t = {
+    en: {
+      pageTitle: "Question Types",
+      search: "Search by name or title",
+      create: "Create",
+      name: "Name",
+      template: "Template",
+      team: "Teams",
+      columnTitle: "Title",
+      description: "Description",
+      link: "Link",
+      actions: "Actions",
+      createType: "Create Question Type",
+      editType: "Edit Question Type",
+      deleteType: "Delete Question Type",
+      deleteConfirmation: "Are you sure you want to delete this question type?",
+      deleteWarning: "This action cannot be undone.",
+      cancel: "Cancel",
+      save: "Save",
+      delete: "Delete",
+      required: "Required",
+      showing: "Showing",
+      of: "of",
+      perPage: "per page",
+      rowsPerPage: "Rows per page",
+    },
+    vi: {
+      pageTitle: "Loại câu hỏi",
+      search: "Tìm kiếm theo tên hoặc tiêu đề",
+      create: "Tạo mới",
+      name: "Tên",
+      template: "Mẫu",
+      team: "Nhóm",
+      columnTitle: "Tiêu đề",
+      description: "Mô tả",
+      link: "Liên kết",
+      actions: "Thao tác",
+      createType: "Tạo loại câu hỏi",
+      editType: "Chỉnh sửa loại câu hỏi",
+      deleteType: "Xóa loại câu hỏi",
+      deleteConfirmation: "Bạn có chắc chắn muốn xóa loại câu hỏi này?",
+      deleteWarning: "Hành động này không thể hoàn tác.",
+      cancel: "Hủy",
+      save: "Lưu",
+      delete: "Xóa",
+      required: "Bắt buộc",
+      showing: "Hiển thị",
+      of: "trong số",
+      perPage: "mỗi trang",
+      rowsPerPage: "Hàng mỗi trang",
+    }
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="flex flex-col space-y-6">
+        {/* Header */}
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold">{t[language].pageTitle}</h1>
+        </div>
+
+        {/* Search and Actions */}
+        <div className="flex items-center justify-between gap-4">
+          <div className="relative flex-1">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder={t[language].search}
+              className="pl-8"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+          <Button onClick={() => setIsCreateDialogOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t[language].create}
+          </Button>
+        </div>
+
+        {/* Table */}
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="whitespace-nowrap">{t[language].name}</TableHead>
+                <TableHead className="whitespace-nowrap">{t[language].template}</TableHead>
+                <TableHead className="whitespace-nowrap">{t[language].team}</TableHead>
+                <TableHead className="whitespace-nowrap">{t[language].columnTitle}</TableHead>
+                <TableHead className="whitespace-nowrap">{t[language].link}</TableHead>
+                <TableHead className="whitespace-nowrap text-right">{t[language].actions}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {paginatedTypes.map((type) => (
+                <TableRow key={type.id}>
+                  <TableCell className="whitespace-nowrap max-w-[150px] truncate">{type.name}</TableCell>
+                  <TableCell className="whitespace-nowrap max-w-[150px] truncate">{type.template}</TableCell>
+                  <TableCell className="whitespace-nowrap max-w-[150px] truncate">{type.team}</TableCell>
+                  <TableCell className="whitespace-nowrap max-w-[200px] truncate">{type.title}</TableCell>
+                  <TableCell className="whitespace-nowrap max-w-[200px] truncate">
+                    <a
+                      href={type.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 hover:underline"
+                    >
+                      {type.link}
+                    </a>
+                  </TableCell>
+                  <TableCell className="text-right whitespace-nowrap">
+                    <div className="flex justify-end gap-2">
+                      <Button variant="ghost" size="icon" onClick={() => handleEdit(type)}>
+                        <Edit2 className="h-4 w-4" />
+                      </Button>
+                      <Button variant="ghost" size="icon" onClick={() => handleDelete(type)}>
+                        <Trash2 className="h-4 w-4 text-red-500" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Pagination Controls */}
+        <div className="flex justify-between items-center">
+          <div className="flex items-center space-x-2">
+            <Select
+              value={rowsPerPage.toString()}
+              onValueChange={(value) => {
+                setRowsPerPage(parseInt(value));
+                setCurrentPage(1);
+              }}
+            >
+              <SelectTrigger className="w-[100px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[5, 10, 20, 30, 40, 50].map((pageSize) => (
+                  <SelectItem key={pageSize} value={pageSize.toString()}>
+                    {pageSize} {t[language].perPage}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <span className="text-sm text-muted-foreground">
+              {t[language].showing} {((currentPage - 1) * rowsPerPage) + 1}-
+              {Math.min(currentPage * rowsPerPage, filteredTypes.length)} {t[language].of}{" "}
+              {filteredTypes.length}
+            </span>
+          </div>
+          <CustomPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            rowsPerPage={rowsPerPage}
+            onPageChange={setCurrentPage}
+            onRowsPerPageChange={setRowsPerPage}
+            translations={{
+              showing: t[language].showing,
+              of: t[language].of,
+              perPage: t[language].perPage
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Create/Edit Dialog */}
+      <Dialog open={isCreateDialogOpen || isEditDialogOpen} onOpenChange={(open) => {
+        if (!open) {
+          setIsCreateDialogOpen(false);
+          setIsEditDialogOpen(false);
+          setEditingType(null);
+        }
+      }}>
+        <DialogContent className="sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>
+              {isCreateDialogOpen ? t[language].createType : t[language].editType}
+            </DialogTitle>
+          </DialogHeader>
+          
+          <div className="space-y-4 py-4">
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="name">
+                  {t[language].name} <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="name"
+                  value={editingType?.name || ''}
+                  onChange={(e) => setEditingType(prev => ({ ...prev!, name: e.target.value }))}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="title">
+                  {t[language].columnTitle} <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="title"
+                  value={editingType?.title || ''}
+                  onChange={(e) => setEditingType(prev => ({ ...prev!, title: e.target.value }))}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="description">
+                  {t[language].description}
+                </Label>
+                <textarea
+                  id="description"
+                  className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  value={editingType?.description || ''}
+                  onChange={(e) => setEditingType(prev => ({ ...prev!, description: e.target.value }))}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="template">
+                  {t[language].template} <span className="text-red-500">*</span>
+                </Label>
+                <Select
+                  value={editingType?.template || ''}
+                  onValueChange={(value) => setEditingType(prev => ({ ...prev!, template: value }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select template" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Rule">Rule</SelectItem>
+                    <SelectItem value="Default">Default</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="team">
+                  {t[language].team}
+                </Label>
+                <Input
+                  id="team"
+                  value={editingType?.team || ''}
+                  onChange={(e) => setEditingType(prev => ({ ...prev!, team: e.target.value }))}
+                />
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => {
+              setIsCreateDialogOpen(false);
+              setIsEditDialogOpen(false);
+              setEditingType(null);
+            }}>
+              {t[language].cancel}
+            </Button>
+            <Button onClick={handleSaveEdit}>
+              {t[language].save}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t[language].deleteType}</DialogTitle>
+            <DialogDescription>
+              {t[language].deleteConfirmation}
+              <br />
+              <span className="text-red-500">{t[language].deleteWarning}</span>
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
+              {t[language].cancel}
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmDelete}>
+              {t[language].delete}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default QuestionTypeManagement; 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,9 @@ import TeamsManagement from "@/components/TeamsManagement";
 import AppliesManagement from "@/components/AppliesManagement";
 import InterviewManagement from "@/components/InterviewManagement";
 import RuleAssessmentManagement from "@/components/RuleAssessmentManagement";
+import QuestionTypeManagement from "@/components/QuestionTypeManagement";
+import QuestionManagement from "@/components/QuestionManagement";
+import QuestionHistoryManagement from "@/components/QuestionHistoryManagement";
 import { cn } from "@/lib/utils";
 
 const Index = () => {
@@ -93,6 +96,12 @@ const Index = () => {
         return <InterviewManagement language={language} />;
       case "rule-assessment":
         return <RuleAssessmentManagement language={language} />;
+      case "type":
+        return <QuestionTypeManagement language={language} />;
+      case "questions":
+        return <QuestionManagement language={language} />;
+      case "history":
+        return <QuestionHistoryManagement language={language} />;
       default:
         return <Placeholder 
           title={getTranslatedTitle(activeItem)} 


### PR DESCRIPTION
🧠 Pull Request: Triển khai giao diện và logic Q&A
Nội dung đã làm:

Question Types Management

Hiển thị danh sách loại bài kiểm tra (name, template, team, link...).

Thêm chức năng tạo, chỉnh sửa, xóa loại câu hỏi.

Questions Management

Giao diện danh sách câu hỏi theo loại.

Tìm kiếm, thêm mới, chỉnh sửa, xóa câu hỏi.

Import/Export câu hỏi (UI only).

History (Lịch sử làm bài)

Hiển thị kết quả làm bài của ứng viên.

Bao gồm ngày thi, email, tên, kết quả, số câu đúng, loại bài thi.

Có lọc theo email và loại bài thi.